### PR TITLE
Random doubles inadvertently rounded to zero

### DIFF
--- a/src/func/svm/SequentialMinimalOptimization.java
+++ b/src/func/svm/SequentialMinimalOptimization.java
@@ -220,7 +220,7 @@ public class SequentialMinimalOptimization implements Trainer {
         }
         // if the second choice hueristic fails we look
         // at all non bound indices, starting from a random point
-        int startI = (int) Math.random() * a.length;
+        int startI = (int) (Math.random() * a.length);
         int i = startI;
         do {
             if (!isBound(i) && takeStep(i, j, ej)) {
@@ -230,7 +230,7 @@ public class SequentialMinimalOptimization implements Trainer {
         } while (i != startI);
         // if that fails we look at all of the indices, starting from
         // a random point
-        startI = (int) Math.random() * a.length;
+        startI = (int) (Math.random() * a.length);
         i = startI;
         do {
             if (takeStep(i, j, ej)) {

--- a/src/func/svm/SingleClassSequentialMinimalOptimization.java
+++ b/src/func/svm/SingleClassSequentialMinimalOptimization.java
@@ -216,7 +216,7 @@ public class SingleClassSequentialMinimalOptimization implements Trainer {
         }
         // if the second choice hueristic fails we look
         // at all non bound indices, starting from a random point
-        int startI = (int) Math.random() * a.length;
+        int startI = (int) (Math.random() * a.length);
         i = startI;
         do {
             if (!isBound(i) && takeStep(i, j, oj)) {
@@ -226,7 +226,7 @@ public class SingleClassSequentialMinimalOptimization implements Trainer {
         } while (i != startI);
         // if that fails we look at all of the indices, starting from
         // a random point
-        startI = (int) Math.random() * a.length;
+        startI = (int) (Math.random() * a.length);
         i = startI;
         do {
             if (takeStep(i, j, oj)) {
@@ -329,7 +329,7 @@ public class SingleClassSequentialMinimalOptimization implements Trainer {
             return true;
         }
         // use any other non bound alpha
-        int startK = (int) Math.random() * a.length;
+        int startK = (int) (Math.random() * a.length);
         int k = startK;
         do {
             if (!isBound(k)) {


### PR DESCRIPTION
Due to operator precedence, random doubles are being cast to int before multiplication. As values returned by Math.random are on the interval [0, 1], the values returned will always be 0 under an integer cast.
