### PR TITLE
Replace recursive partitioning in ABAGAILArrays

### DIFF
--- a/src/util/ABAGAILArrays.java
+++ b/src/util/ABAGAILArrays.java
@@ -213,18 +213,19 @@ public class ABAGAILArrays {
      * @return the ith smallest number
      */
     public static double randomizedSelect(double[] a, int s, int e, int i) {
-        if (s == e - 1) {
-            return a[s];
+        while (s < e - 1) {
+        	int splitI = randomPartition(a, s, e);
+        	int orderOfSplit = splitI - s + 1;
+        	if (orderOfSplit == i) {
+        		return a[splitI];
+        	} else if (i < orderOfSplit) {
+        		e = splitI;
+        		continue;
+        	}
+    		s = splitI + 1;
+    		i -= orderOfSplit;
         }
-        int splitI = randomPartition(a, s, e);
-        int orderOfSplit = splitI - s + 1;
-        if (orderOfSplit == i) {
-           return a[splitI]; 
-        } else if (i < orderOfSplit) {
-            return randomizedSelect(a, s, splitI, i);
-        } else {
-            return randomizedSelect(a, splitI + 1, e, i - orderOfSplit);
-        }
+        return a[s];
     }
     
     /**


### PR DESCRIPTION
The recursive implementation of the randomizedSelect function can cause stack overflow errors for large arrays. 

Stack overflow depth is not a documented feature of Java, but it is dependent on the available virtual memory. [[source]](http://www.odi.ch/weblog/posting.php?posting=411) This corrects a stack overflow error caused by MIMIC sample size >7000 running on my late 2010 MacBook Air with 2048 mb allocated to the Java runtime.
