### PR TITLE
Gets rounded values for discrete features.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ABAGAIL.jar
 *.war
 *.ear
 manifest.mf
+/bin

--- a/src/shared/Instance.java
+++ b/src/shared/Instance.java
@@ -151,7 +151,7 @@ public class Instance implements Serializable, Copyable {
      * @return the value
      */
     public int getDiscrete(int i) {
-        return (int) data.get(i);
+        return (int) Math.round(data.get(i));
     }
     
     /**


### PR DESCRIPTION
@pushkar 

shared.Instance#getDiscrete(int i) should not flatten double-valued
features. Rounding is more appropriate.
