### PR TITLE
Fix bogus returns when dealing with multiple discrete outputs

### DIFF
--- a/src/func/nn/Layer.java
+++ b/src/func/nn/Layer.java
@@ -84,6 +84,7 @@ public class Layer implements Serializable {
         for (int i = 1; i < getNodeCount(); i++) {
             if (getNode(i).getActivation() > largestValue) {
                 largest = i;
+                largestValue = getNode(largest).getActivation();
             }
         }
         return largest;

--- a/src/shared/Instance.java
+++ b/src/shared/Instance.java
@@ -89,7 +89,7 @@ public class Instance implements Serializable, Copyable {
     }
     
     /**
-     * Make a new discrete input ouptu instance
+     * Make a new discrete input output instance
      * @param i the input
      * @param o the output
      */


### PR DESCRIPTION
When looking for largest activating output, code was incorrect.
