### PR TITLE
Fix build.xml. additionalparam attribute should be with javadoc.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,8 +37,8 @@
 		<delete dir="${jdocs.dir}" />
 	</target>
 
-	<target name="javadoc" depends="prepare" additionalparam="subpackages">
-		<javadoc sourcepath="${src.dir}" destdir="${jdocs.dir}" />
+	<target name="javadoc" depends="prepare">
+		<javadoc sourcepath="${src.dir}" destdir="${jdocs.dir}" additionalparam="subpackages"/>
 	</target>
 
 	<target name = "all" depends = "compile,jar"/>


### PR DESCRIPTION
With the fix, ant is able to build the jar.

```
$ ant
Buildfile: /Users/skumaran/projects/ABAGAIL/build.xml

init:

prepare:

compile:
    [javac] /Users/skumaran/projects/ABAGAIL/build.xml:17: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds

jar:
   [delete] Deleting: /Users/skumaran/projects/ABAGAIL/ABAGAIL.jar
      [jar] Building jar: /Users/skumaran/projects/ABAGAIL/ABAGAIL.jar

all:

BUILD SUCCESSFUL
Total time: 0 seconds
```