### PR TITLE
Fix XORTestNoBackprop. check label only if it exists.

### DIFF
--- a/src/shared/tester/Comparison.java
+++ b/src/shared/tester/Comparison.java
@@ -44,10 +44,12 @@ public class Comparison {
                 return false;
             }
         }
-        // Check label values.
-        for (int i = 0; i < expected.getLabel().size(); i++) {
-            if (!isLabelCorrect(i)) {
-                return false;
+        // Check label values if it exists
+        if (expected.getLabel() != null) {
+            for (int i = 0; i < expected.getLabel().size(); i++) {
+                if (!isLabelCorrect(i)) {
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
**With out the fix [master]**

```
$ java -cp ./ABAGAIL.jar opt.test.XORTestNoBackprop
Exception in thread "main" java.lang.NullPointerException
	at shared.tester.Comparison.isAllCorrect(Unknown Source)
	at shared.tester.ConfusionMatrixTestMetric$MatrixEntry.equals(Unknown Source)
	at java.util.HashMap.getNode(HashMap.java:571)
	at java.util.HashMap.containsKey(HashMap.java:595)
	at shared.tester.ConfusionMatrixTestMetric.addResult(Unknown Source)
	at shared.tester.NeuralNetworkTester.test(Unknown Source)
	at opt.test.XORTestNoBackprop.main(Unknown Source)
```

**With fix [patch applied]**

```	
$ java -cp ./ABAGAIL.jar opt.test.XORTestNoBackprop
Correctly Classified Instances: 0.00%
Incorrectly Classified Instances: 100.00%
Confusion Matrix:

	0	1	?
0	0	0	2
1	0	0	2
```