### PR TITLE
K-D Tree Build Improvements

### DIFF
--- a/src/func/inst/KDTree.java
+++ b/src/func/inst/KDTree.java
@@ -88,9 +88,7 @@ public class KDTree implements Serializable {
             return nodes[start];
         }
         // choose splitter
-        //int splitterIndex = chooseSplitterRandom(nodes, start, end);
         int splitterIndex = chooseApproxBestSplitter(nodes, start, end, depth);
-        
         KDTreeNode splitter = nodes[splitterIndex];
         //  partition based on splitter
         splitterIndex = partition(nodes, start, end, splitterIndex);
@@ -152,7 +150,10 @@ public class KDTree implements Serializable {
     
     /**
      * Choose an approximate best splitter
-     * Picks the median element from 10 randomly picked elements in nodes
+     * Picks the median element from 5 randomly picked elements between start and end
+     * If end-start is less than 5, it picks the median from the whole range.
+     * It selects dimensions in order, so that each level of the final KDTree
+     * splits on a different dimension
      * @param nodes the nodes to choose from
      * @param start the starting index
      * @param end the ending index
@@ -161,7 +162,8 @@ public class KDTree implements Serializable {
      */
     private int chooseApproxBestSplitter(KDTreeNode[] nodes, int start, int end, int depth){
         int SAMPLE_SIZE = 5;
-        int dimension = depth % dimensions;
+        //Ensure that each level of the tree selects on a different dimension
+        int dimension = depth % dimensions; 
         int splitter;
         if (end-start <= SAMPLE_SIZE){
             for (int n = start; n < end; n++){

--- a/src/func/inst/KDTree.java
+++ b/src/func/inst/KDTree.java
@@ -192,6 +192,16 @@ public class KDTree implements Serializable {
         return start;
     }
 
+    /**
+    * This function implements medianOfMedians on the passed in KDTreeNode Array
+    * this fn returns an acceptable splitter, guarenteed to be greater than 25%
+    * of the data and less than 25% of the data.
+    *
+    * @param nodes the list of KDTreeNodes to search through
+    * @param start the lower bound of the search, inclusive
+    * @param end the upper bound of the search, exclusive
+    * @return the index of the splitter
+    */
     private int medianOfMedians(KDTreeNode[] nodes, int start, int end){
         int MEDIAN_SIZE = 5;
         int partitions;

--- a/src/func/test/KNNClassifierAbaloneTest.java
+++ b/src/func/test/KNNClassifierAbaloneTest.java
@@ -20,7 +20,7 @@ public class KNNClassifierAbaloneTest {
     public static void main(String[] args){
         Instance[] instances = initializeAbaloneInstances();
         Instance[] training = new Instance[3000];
-        Instance[] testing = new Instance[1601];
+        Instance[] testing = new Instance[1177];
         for (int i = 0; i < training.length; i++){
             training[i] = instances[i];
         }
@@ -31,7 +31,7 @@ public class KNNClassifierAbaloneTest {
         KDTree tree = new KDTree(new DataSet(training));
         buildTime = System.nanoTime() - buildTime;
         System.out.println("BuildTime = " + buildTime);
-        
+
         for (int k = 1; k < 10; k++){
             long testTime = 0;
             for (int i = 0; i < testing.length; i++){
@@ -43,10 +43,10 @@ public class KNNClassifierAbaloneTest {
             testTime /= testing.length;
             System.out.println("K = " + k + ", average search time = " + testTime);
         }
-        
-        
+
+
     }
-    
+
     private static Instance[] initializeAbaloneInstances() {
 
         double[][][] attributes = new double[4177][][];

--- a/src/func/test/KNNClassifierAbaloneTest.java
+++ b/src/func/test/KNNClassifierAbaloneTest.java
@@ -18,7 +18,7 @@ import shared.Instance;
 public class KNNClassifierAbaloneTest {
 
     public static void main(String[] args){
-        Instance[] instances = initializeInstances();
+        Instance[] instances = initializeAbaloneInstances();
         Instance[] training = new Instance[3000];
         Instance[] testing = new Instance[1601];
         for (int i = 0; i < training.length; i++){
@@ -45,41 +45,6 @@ public class KNNClassifierAbaloneTest {
         }
         
         
-    }
-    
-    private static Instance[] initializeInstances() {
-
-        double[][][] attributes = new double[4601][][];
-
-        try {
-            BufferedReader br = new BufferedReader(new FileReader(new File("src/opt/test/spam.txt.csv")));
-
-            for(int i = 0; i < attributes.length; i++) {
-                Scanner scan = new Scanner(br.readLine());
-                scan.useDelimiter(",");
-
-                attributes[i] = new double[2][];
-                attributes[i][0] = new double[57]; // 57 attributes
-                attributes[i][1] = new double[1];
-
-                for(int j = 0; j < 57; j++)
-                    attributes[i][0][j] = Double.parseDouble(scan.next());
-
-                attributes[i][1][0] = Double.parseDouble(scan.next());
-            }
-        }
-        catch(Exception e) {
-            e.printStackTrace();
-        }
-
-        Instance[] instances = new Instance[attributes.length];
-
-        for(int i = 0; i < instances.length; i++) {
-            instances[i] = new Instance(attributes[i][0]);
-            instances[i].setLabel(new Instance(attributes[i][1][0]));
-        }
-
-        return instances;
     }
     
     private static Instance[] initializeAbaloneInstances() {

--- a/src/func/test/KNNClassifierAbaloneTest.java
+++ b/src/func/test/KNNClassifierAbaloneTest.java
@@ -1,0 +1,120 @@
+package func.test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.Scanner;
+
+import func.inst.KDTree;
+import opt.test.AbaloneTest;
+import shared.DataSet;
+import shared.Instance;
+
+/**
+ * KNN test built to test the speed of splitter selectors in func.inst.KDTree
+ * @author Robert Smith smithrobertlawrence@gmail.com
+ * @version 1.0
+ */
+public class KNNClassifierAbaloneTest {
+
+    public static void main(String[] args){
+        Instance[] instances = initializeInstances();
+        Instance[] training = new Instance[3000];
+        Instance[] testing = new Instance[1601];
+        for (int i = 0; i < training.length; i++){
+            training[i] = instances[i];
+        }
+        for (int i = 0; i < testing.length; i++){
+            testing[i] = instances[training.length+i];
+        }
+        long buildTime = System.nanoTime();
+        KDTree tree = new KDTree(new DataSet(training));
+        buildTime = System.nanoTime() - buildTime;
+        System.out.println("BuildTime = " + buildTime);
+        
+        for (int k = 1; k < 10; k++){
+            long testTime = 0;
+            for (int i = 0; i < testing.length; i++){
+                long searchTime = System.nanoTime();
+                tree.knn(testing[i], k);
+                searchTime = System.nanoTime() - searchTime;
+                testTime += searchTime;
+            }
+            testTime /= testing.length;
+            System.out.println("K = " + k + ", average search time = " + testTime);
+        }
+        
+        
+    }
+    
+    private static Instance[] initializeInstances() {
+
+        double[][][] attributes = new double[4601][][];
+
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(new File("src/opt/test/spam.txt.csv")));
+
+            for(int i = 0; i < attributes.length; i++) {
+                Scanner scan = new Scanner(br.readLine());
+                scan.useDelimiter(",");
+
+                attributes[i] = new double[2][];
+                attributes[i][0] = new double[57]; // 57 attributes
+                attributes[i][1] = new double[1];
+
+                for(int j = 0; j < 57; j++)
+                    attributes[i][0][j] = Double.parseDouble(scan.next());
+
+                attributes[i][1][0] = Double.parseDouble(scan.next());
+            }
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
+
+        Instance[] instances = new Instance[attributes.length];
+
+        for(int i = 0; i < instances.length; i++) {
+            instances[i] = new Instance(attributes[i][0]);
+            instances[i].setLabel(new Instance(attributes[i][1][0]));
+        }
+
+        return instances;
+    }
+    
+    private static Instance[] initializeAbaloneInstances() {
+
+        double[][][] attributes = new double[4177][][];
+
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(new File("src/opt/test/abalone.txt")));
+
+            for(int i = 0; i < attributes.length; i++) {
+                Scanner scan = new Scanner(br.readLine());
+                scan.useDelimiter(",");
+
+                attributes[i] = new double[2][];
+                attributes[i][0] = new double[7]; // 7 attributes
+                attributes[i][1] = new double[1];
+
+                for(int j = 0; j < 7; j++)
+                    attributes[i][0][j] = Double.parseDouble(scan.next());
+
+                attributes[i][1][0] = Double.parseDouble(scan.next());
+            }
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
+
+        Instance[] instances = new Instance[attributes.length];
+
+        for(int i = 0; i < instances.length; i++) {
+            instances[i] = new Instance(attributes[i][0]);
+            // classifications range from 0 to 30; split into 0 - 14 and 15 - 30
+            instances[i].setLabel(new Instance(attributes[i][1][0] < 15 ? 0 : 1));
+        }
+
+        return instances;
+    }
+}


### PR DESCRIPTION
This change create more balanced K-D trees, which in turn reduces the time for each knn search. It does this by at each node, using the median of medians algorithm to find an acceptable median in linear time. Previously, a random element was chosen (this can still be enabled if desired). In addition, the algorithm now iterates through the dimensions in the data, ensuring that a different "splitter" dimension is chosen at each level in the tree.

I ran tests on the Abalone data set and on a Street Data data set (http://archive.ics.uci.edu/ml/datasets/3D+Road+Network+%28North+Jutland%2C+Denmark%29), and this change increases the KDTree build time slightly for smaller (a few thousand instances) datasets, and by a factor of 5 (.1s -> .5s) for a dataset with a half million instances. However it reduces the average knn search time by about 20% (smaller dataset) to 30% (larger), which was relatively constant from k=1 to k=10. Because the average time spent on each search on my computer was ~.03ms for the abalone dataset (3000 instances were used to build the tree) and ~.1ms on the street dataset (~400,000 instances), this change will save time when the KDTree is used for more than a few thousand knn classifications. For higher dimensional problems, even fewer iterations may be necessary.