### PR TITLE
Fix bug due to in-place mutation

### DIFF
--- a/src/opt/ga/StandardGeneticAlgorithm.java
+++ b/src/opt/ga/StandardGeneticAlgorithm.java
@@ -104,7 +104,7 @@ public class StandardGeneticAlgorithm extends OptimizationAlgorithm {
         // elite for the rest
         for (int i = toMate; i < newPopulation.length; i++) {
             int j = dd.sample(null).getDiscrete();
-            newPopulation[i] = population[j];
+            newPopulation[i] = (Instance) population[j].copy();
             newValues[i] = values[j];
         }
         // mutate


### PR DESCRIPTION
Since instances from the old population were being used directly rather than copied, you could end up with the same instance appearing more than once in the same population.  If it is then mutated, only one of the values in `newValues` will get set to -1, whereas the mutation affects all of the places it appears.  As a result, the `values` array in the end can contain incorrect values, which can lead to an incorrect instance getting returned by `getOptimal` (it may return the mutated instance based on the value it had before the mutation).