### PR TITLE
Fix a tiny BUG in BackPropagationNetworkFactory.java

### DIFF
--- a/src/func/nn/backprop/BackPropagationNetworkFactory.java
+++ b/src/func/nn/backprop/BackPropagationNetworkFactory.java
@@ -82,7 +82,8 @@ public class BackPropagationNetworkFactory {
         for (int i = 0; i < nodeCounts.length-1; i++) {
             transfers[i] = transfer;
         }
-		return createRegressionNetwork(nodeCounts, new HyperbolicTangentSigmoid());
+		//return createRegressionNetwork(nodeCounts, new HyperbolicTangentSigmoid());
+		return createRegressionNetwork(nodeCounts, transfers);
 	}
 
 	/**


### PR DESCRIPTION
A tiny bug at line 85
When I ran func.test.NNRegressionTest.java, a StackOverflowException was thrown. I found it is because createRegressionNetwork(int[] nodeCounts,DifferentiableActivationFunction transfer) at line 79 invokes itself endlessly...